### PR TITLE
Added edgeR at v3.21.10

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libs/edgeR"]
+	path = libs/edgeR
+	url = https://git.bioconductor.org/packages/edgeR


### PR DESCRIPTION
Since it is difficult to browse the edgeR source on bioconductor (AFAIK no online git repo viewer), I have pinned a submodule here at `v3.21.10`.

You can clone both this repository and the `edgeR` repository at the same time with:

```bash
❯ git clone --recursive git@github.com:r-bioinformatics/edgePy.git
```

This locks us into a version so we are all looking at the same source.

If you already cloned this repo and would like to fetch the `edgeR` source you can do:

```bash
# After PR is merged
❯ cd edgePy && git checkout master && git pull
❯ git submodule update --init --recursive
```
